### PR TITLE
Structures. Added quotes to syntax in order to match the output provided 

### DIFF
--- a/cfml100mins.markdown
+++ b/cfml100mins.markdown
@@ -786,7 +786,7 @@ In the second chunk of the example, we add a new key and value to the structure.
 <cfscript>
 StructSort(ages);
 for(student in ages) {
- WriteOutput ("#student# is #ages[student]# years old.<br />");
+ WriteOutput ('"#student# is #ages[student]# years old.<br />"');
 }
 </cfscript>
 ```


### PR DESCRIPTION
Structures. Added quotes to syntax in order to match the output provided by the tag example. 
