### PR TITLE
Updated url to Ruby in 100 Minutes

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # readme
 
-CFML in 100 minutes was modified from [Ruby in 100 Minutes](http://jumpstartlab.com/resources/ruby-jumpstart/ruby/)
+CFML in 100 minutes was modified from [Ruby in 100 Minutes](http://tutorials.jumpstartlab.com/projects/ruby_in_100_minutes.html)
 
 ## Where is CFML in 100 minutes?
 


### PR DESCRIPTION
The Ruby in 100 Minutes URL was out of date. Found the new link and replaced it in this file.